### PR TITLE
新增手动分页支持排序

### DIFF
--- a/paging_test.go
+++ b/paging_test.go
@@ -1,0 +1,51 @@
+package gox
+
+import (
+	`fmt`
+	`testing`
+)
+
+func TestManualPaging_Sort(t *testing.T) {
+	type test struct {
+		id         int64
+		sum        int
+		count      int
+		proportion float32
+	}
+
+	originData := []test{
+		{id: 3, sum: 76, count: 3, proportion: 0.4},
+		{id: 6, sum: 86, count: 2, proportion: 0.3},
+		{id: 2, sum: 70, count: 2, proportion: 0.6},
+		{id: 4, sum: 76, count: 3, proportion: 0.4},
+		{id: 5, sum: 70, count: 1, proportion: 0.8},
+		{id: 1, sum: 86, count: 2, proportion: 0.5},
+	}
+
+	expected := []test{
+		{id: 1, sum: 86, count: 2, proportion: 0.5},
+		{id: 6, sum: 86, count: 2, proportion: 0.3},
+		{id: 3, sum: 76, count: 3, proportion: 0.4},
+		{id: 4, sum: 76, count: 3, proportion: 0.4},
+		{id: 2, sum: 70, count: 2, proportion: 0.6},
+		{id: 5, sum: 70, count: 1, proportion: 0.8},
+	}
+
+	sortedData := NewManualPaging(originData, ManualPagingInfo{
+		page:    2,
+		perPage: 5,
+		SortBy:  "sum DESC,count DESC,proportion DESC,id ASC",
+	}).Sort()
+
+	results := sortedData.GetSliceInterface().([]test)
+	for _, result := range results {
+		fmt.Println(result)
+	}
+
+	for index := range expected {
+		if results[index] != expected[index] {
+			t.Fatalf("第%v元素,期望：%v，实际：%v", index, expected[index], results[index])
+		}
+	}
+
+}


### PR DESCRIPTION
1.新增手动分页支持排序
2.新增手动分页排序paging_test.go用于测试多字段排序结果
3.修改了手动分页方法，改为manualPaging结构体方法，便于排序后再获取分页内容

fix:
1.修复了分页操作返回为空值的时候会返回空slice的错误。
