### PR TITLE
增强了排序方法以及修复一些实际场景的错误

### DIFF
--- a/paging.go
+++ b/paging.go
@@ -71,6 +71,36 @@ func (s SortBy) sorters() sorters {
 	return sorters
 }
 
+// 排序字段转换 下划线转大驼峰
+func (s sorters) fieldMarshal() sorters {
+	for index, singleSorter := range s {
+		field := singleSorter.Field
+		if field == "" {
+			continue
+		}
+
+		temp := strings.Split(field, "_")
+		var str string
+		for _, value := range temp {
+			runeValue := []rune(value)
+			if len(runeValue) > 0 {
+				if runeValue[0] >= 'a' && runeValue[0] <= 'z' {
+					// 首字母大写
+					runeValue[0] -= 32
+				}
+				str += string(runeValue)
+			}
+		}
+
+		s[index] = sorter{
+			Field:     str,
+			Ascending: singleSorter.Ascending,
+		}
+	}
+
+	return s
+}
+
 func (s sorters) orderBy() string {
 	if len(s) == 0 {
 		return ""
@@ -156,7 +186,7 @@ func NewManualPaging(slice interface{}, paging Paging) *manualPaging {
 }
 
 func (mp *manualPaging) Sort(sortBy SortBy) *manualPaging {
-	sorters := sortBy.sorters()
+	sorters := sortBy.sorters().fieldMarshal()
 	if len(sorters) == 0 {
 		panic(sortBy + ":缺少合法的排序字段")
 	}

--- a/paging.go
+++ b/paging.go
@@ -199,13 +199,21 @@ func (mp *manualPaging) Sort(sortBy SortBy) *manualPaging {
 	return mp
 }
 
+func structValue(value reflect.Value) reflect.Value {
+	if reflect.Ptr == value.Kind() {
+		return value.Elem()
+	}
+
+	return value
+}
+
 func (mp *manualPaging) compare(i, j, sorterIndex int) bool {
 	if sorterIndex > len(mp.sorters) {
 		// It means two same values when function runs in this judge true
 		return false
 	}
-	firstValue := mp.sliceValue.Index(i).FieldByName(mp.sorters[sorterIndex].Field)
-	secondValue := mp.sliceValue.Index(j).FieldByName(mp.sorters[sorterIndex].Field)
+	firstValue := structValue(mp.sliceValue.Index(i)).FieldByName(mp.sorters[sorterIndex].Field)
+	secondValue := structValue(mp.sliceValue.Index(j)).FieldByName(mp.sorters[sorterIndex].Field)
 
 	if firstValue.Kind() != secondValue.Kind() {
 		panic("cannot sort the values with different types")

--- a/paging.go
+++ b/paging.go
@@ -188,7 +188,7 @@ func NewManualPaging(slice interface{}, paging Paging) *manualPaging {
 func (mp *manualPaging) Sort(sortBy SortBy) *manualPaging {
 	sorters := sortBy.sorters().fieldMarshal()
 	if len(sorters) == 0 {
-		panic(sortBy + ":缺少合法的排序字段")
+		return mp
 	}
 	mp.sorters = sorters
 

--- a/paging_test.go
+++ b/paging_test.go
@@ -7,34 +7,34 @@ import (
 
 func TestManualPaging_Sort(t *testing.T) {
 	type test struct {
-		id         int64
-		sum        int
-		count      int
-		proportion float32
+		Id           int64
+		CourseSum    int
+		TeacherCount int
+		Proportion   float32
 	}
 
 	originData := []test{
-		{id: 3, sum: 76, count: 3, proportion: 0.4},
-		{id: 6, sum: 86, count: 2, proportion: 0.3},
-		{id: 2, sum: 70, count: 2, proportion: 0.6},
-		{id: 4, sum: 76, count: 3, proportion: 0.4},
-		{id: 5, sum: 70, count: 1, proportion: 0.8},
-		{id: 1, sum: 86, count: 2, proportion: 0.5},
+		{Id: 3, CourseSum: 76, TeacherCount: 3, Proportion: 0.4},
+		{Id: 6, CourseSum: 86, TeacherCount: 2, Proportion: 0.3},
+		{Id: 2, CourseSum: 70, TeacherCount: 2, Proportion: 0.6},
+		{Id: 4, CourseSum: 76, TeacherCount: 3, Proportion: 0.4},
+		{Id: 5, CourseSum: 70, TeacherCount: 1, Proportion: 0.8},
+		{Id: 1, CourseSum: 86, TeacherCount: 2, Proportion: 0.5},
 	}
 
 	expected := []test{
-		{id: 1, sum: 86, count: 2, proportion: 0.5},
-		{id: 6, sum: 86, count: 2, proportion: 0.3},
-		{id: 3, sum: 76, count: 3, proportion: 0.4},
-		{id: 4, sum: 76, count: 3, proportion: 0.4},
-		{id: 2, sum: 70, count: 2, proportion: 0.6},
-		{id: 5, sum: 70, count: 1, proportion: 0.8},
+		{Id: 1, CourseSum: 86, TeacherCount: 2, Proportion: 0.5},
+		{Id: 6, CourseSum: 86, TeacherCount: 2, Proportion: 0.3},
+		{Id: 3, CourseSum: 76, TeacherCount: 3, Proportion: 0.4},
+		{Id: 4, CourseSum: 76, TeacherCount: 3, Proportion: 0.4},
+		{Id: 2, CourseSum: 70, TeacherCount: 2, Proportion: 0.6},
+		{Id: 5, CourseSum: 70, TeacherCount: 1, Proportion: 0.8},
 	}
 
 	sortedData := NewManualPaging(originData, Paging{
 		Page:    2,
 		PerPage: 3,
-	}).Sort("sum DESC,count DESC,proportion DESC,id ASC")
+	}).Sort("course_sum DESC,teacher_count DESC,proportion DESC,id ASC")
 
 	results := sortedData.GetInterface().([]test)
 	fmt.Println("Slice By Sort:")
@@ -50,9 +50,9 @@ func TestManualPaging_Sort(t *testing.T) {
 
 	pagingResults := sortedData.Paging().([]test)
 	expectedPaging := []test{
-		{id: 4, sum: 76, count: 3, proportion: 0.4},
-		{id: 2, sum: 70, count: 2, proportion: 0.6},
-		{id: 5, sum: 70, count: 1, proportion: 0.8},
+		{Id: 4, CourseSum: 76, TeacherCount: 3, Proportion: 0.4},
+		{Id: 2, CourseSum: 70, TeacherCount: 2, Proportion: 0.6},
+		{Id: 5, CourseSum: 70, TeacherCount: 1, Proportion: 0.8},
 	}
 
 	fmt.Println("Slice By Sort And Paging:")

--- a/paging_test.go
+++ b/paging_test.go
@@ -5,7 +5,71 @@ import (
 	`testing`
 )
 
-func TestManualPaging_Sort(t *testing.T) {
+func TestManualPaging_Sort_PtrSlice(t *testing.T) {
+	type test struct {
+		Id           int64
+		CourseSum    int
+		TeacherCount int
+		Proportion   float32
+	}
+
+	originData := []*test{
+		{Id: 3, CourseSum: 76, TeacherCount: 3, Proportion: 0.4},
+		{Id: 6, CourseSum: 86, TeacherCount: 2, Proportion: 0.3},
+		{Id: 2, CourseSum: 70, TeacherCount: 2, Proportion: 0.6},
+		{Id: 4, CourseSum: 76, TeacherCount: 3, Proportion: 0.4},
+		{Id: 5, CourseSum: 70, TeacherCount: 1, Proportion: 0.8},
+		{Id: 1, CourseSum: 86, TeacherCount: 2, Proportion: 0.5},
+	}
+
+	expected := []*test{
+		{Id: 1, CourseSum: 86, TeacherCount: 2, Proportion: 0.5},
+		{Id: 6, CourseSum: 86, TeacherCount: 2, Proportion: 0.3},
+		{Id: 3, CourseSum: 76, TeacherCount: 3, Proportion: 0.4},
+		{Id: 4, CourseSum: 76, TeacherCount: 3, Proportion: 0.4},
+		{Id: 2, CourseSum: 70, TeacherCount: 2, Proportion: 0.6},
+		{Id: 5, CourseSum: 70, TeacherCount: 1, Proportion: 0.8},
+	}
+
+	sortedData := NewManualPaging(originData, Paging{
+		Page:    2,
+		PerPage: 3,
+	}).Sort("course_sum DESC,teacher_count DESC,proportion DESC,id ASC")
+
+	results := sortedData.GetInterface().([]*test)
+	fmt.Println("Slice By Sort:")
+	for _, result := range results {
+		fmt.Println(result)
+	}
+
+	for index := range expected {
+		if *results[index] != *expected[index] {
+			t.Fatalf("sort(),第%v元素,期望：%v，实际：%v", index, *expected[index], *results[index])
+		}
+	}
+
+	pagingResults := sortedData.Paging().([]*test)
+	expectedPaging := []*test{
+		{Id: 4, CourseSum: 76, TeacherCount: 3, Proportion: 0.4},
+		{Id: 2, CourseSum: 70, TeacherCount: 2, Proportion: 0.6},
+		{Id: 5, CourseSum: 70, TeacherCount: 1, Proportion: 0.8},
+	}
+
+	fmt.Println("Slice By Sort And Paging:")
+	for _, result := range pagingResults {
+		fmt.Println(result)
+	}
+
+	for index := range expectedPaging {
+		if *pagingResults[index] != *expectedPaging[index] {
+			t.Fatalf("sort(),第%v元素,期望：%v，实际：%v", index, *expectedPaging[index], *pagingResults[index])
+		}
+
+	}
+
+}
+
+func TestManualPaging_Sort_StructSlice(t *testing.T) {
 	type test struct {
 		Id           int64
 		CourseSum    int
@@ -46,6 +110,7 @@ func TestManualPaging_Sort(t *testing.T) {
 		if results[index] != expected[index] {
 			t.Fatalf("sort(),第%v元素,期望：%v，实际：%v", index, expected[index], results[index])
 		}
+
 	}
 
 	pagingResults := sortedData.Paging().([]test)
@@ -62,8 +127,9 @@ func TestManualPaging_Sort(t *testing.T) {
 
 	for index := range expectedPaging {
 		if pagingResults[index] != expectedPaging[index] {
-			t.Fatalf("sort(),第%v元素,期望：%v，实际：%v", index, pagingResults[index], expectedPaging[index])
+			t.Fatalf("sort(),第%v元素,期望：%v，实际：%v", index, expectedPaging[index], pagingResults[index])
 		}
+
 	}
 
 }


### PR DESCRIPTION
1.增加了下划线转驼峰的sorters方法 fieldMarshal()更符合场景。
2. manualPaging 支持了对元素为指针的Slice进行排序
3. paging_test.go 增加了对元素为指针的Slice进行测试排序与分页测试
4. sorters 为空时，直接返回manualPaging不参与排序